### PR TITLE
TELAPPS-2740 - Remove the option to find conference by name

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2269,7 +2269,7 @@ paths:
       description: Lists conference participants
       operationId: listConferenceParticipants
       parameters:
-      - description: Uniquely identifies the conference by id or name
+      - description: Uniquely identifies the conference by id
         explode: false
         in: path
         name: conference_id
@@ -2349,7 +2349,7 @@ paths:
       description: Retrieve an existing conference
       operationId: retrieveConference
       parameters:
-      - description: Uniquely identifies the conference by id or name
+      - description: Uniquely identifies the conference by id
         explode: false
         in: path
         name: id
@@ -22520,4 +22520,3 @@ components:
     bearerAuth:
       scheme: bearer
       type: http
-

--- a/docs/ConferenceCommandsApi.md
+++ b/docs/ConferenceCommandsApi.md
@@ -52,7 +52,7 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
@@ -127,14 +127,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Uniquely identifies the conference by id or name
-        ConferenceHoldRequest conferenceHoldRequest = new ConferenceHoldRequest(); // ConferenceHoldRequest | 
+        ConferenceHoldRequest conferenceHoldRequest = new ConferenceHoldRequest(); // ConferenceHoldRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceHoldParticipants(id, conferenceHoldRequest);
             System.out.println(result);
@@ -208,7 +208,7 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
@@ -282,14 +282,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Uniquely identifies the conference by id or name
-        ConferenceMuteRequest conferenceMuteRequest = new ConferenceMuteRequest(); // ConferenceMuteRequest | 
+        ConferenceMuteRequest conferenceMuteRequest = new ConferenceMuteRequest(); // ConferenceMuteRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceMuteParticipants(id, conferenceMuteRequest);
             System.out.println(result);
@@ -357,14 +357,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Uniquely identifies the conference by id or name
-        ConferencePlayRequest conferencePlayRequest = new ConferencePlayRequest(); // ConferencePlayRequest | 
+        ConferencePlayRequest conferencePlayRequest = new ConferencePlayRequest(); // ConferencePlayRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferencePlayAudio(id, conferencePlayRequest);
             System.out.println(result);
@@ -432,14 +432,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Specifies the conference by id or name
-        ConferenceSpeakRequest conferenceSpeakRequest = new ConferenceSpeakRequest(); // ConferenceSpeakRequest | 
+        ConferenceSpeakRequest conferenceSpeakRequest = new ConferenceSpeakRequest(); // ConferenceSpeakRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceSpeakText(id, conferenceSpeakRequest);
             System.out.println(result);
@@ -511,14 +511,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Specifies the conference to record by id or name
-        StartRecordingRequest startRecordingRequest = new StartRecordingRequest(); // StartRecordingRequest | 
+        StartRecordingRequest startRecordingRequest = new StartRecordingRequest(); // StartRecordingRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceStartRecording(id, startRecordingRequest);
             System.out.println(result);
@@ -591,7 +591,7 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
@@ -666,14 +666,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Uniquely identifies the conference by id or name
-        ConferenceUnholdRequest conferenceUnholdRequest = new ConferenceUnholdRequest(); // ConferenceUnholdRequest | 
+        ConferenceUnholdRequest conferenceUnholdRequest = new ConferenceUnholdRequest(); // ConferenceUnholdRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceUnholdParticipants(id, conferenceUnholdRequest);
             System.out.println(result);
@@ -741,14 +741,14 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
         String id = "id_example"; // String | Uniquely identifies the conference by id or name
-        ConferenceUnmuteRequest conferenceUnmuteRequest = new ConferenceUnmuteRequest(); // ConferenceUnmuteRequest | 
+        ConferenceUnmuteRequest conferenceUnmuteRequest = new ConferenceUnmuteRequest(); // ConferenceUnmuteRequest |
         try {
             ConferenceCommandResponse result = apiInstance.conferenceUnmuteParticipants(id, conferenceUnmuteRequest);
             System.out.println(result);
@@ -825,7 +825,7 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
@@ -897,13 +897,13 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
-        String conferenceId = "conferenceId_example"; // String | Uniquely identifies the conference by id or name
+        String conferenceId = "conferenceId_example"; // String | Uniquely identifies the conference by id
         Boolean filterMuted = true; // Boolean | If present, participants will be filtered to those who are/are not muted
         Boolean filterOnHold = true; // Boolean | If present, participants will be filtered to those who are/are not put on hold
         Boolean filterWhispering = true; // Boolean | If present, participants will be filtered to those who are whispering or are not
@@ -934,7 +934,7 @@ public class Example {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **conferenceId** | **String**| Uniquely identifies the conference by id or name |
+ **conferenceId** | **String**| Uniquely identifies the conference by id |
  **filterMuted** | **Boolean**| If present, participants will be filtered to those who are/are not muted | [optional]
  **filterOnHold** | **Boolean**| If present, participants will be filtered to those who are/are not put on hold | [optional]
  **filterWhispering** | **Boolean**| If present, participants will be filtered to those who are whispering or are not | [optional]
@@ -986,7 +986,7 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
@@ -1066,13 +1066,13 @@ public class Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("https://api.telnyx.com/v2");
-        
+
         // Configure HTTP bearer authorization: bearerAuth
         HttpBearerAuth bearerAuth = (HttpBearerAuth) defaultClient.getAuthentication("bearerAuth");
         bearerAuth.setBearerToken("BEARER TOKEN");
 
         ConferenceCommandsApi apiInstance = new ConferenceCommandsApi(defaultClient);
-        String id = "id_example"; // String | Uniquely identifies the conference by id or name
+        String id = "id_example"; // String | Uniquely identifies the conference by id
         try {
             ConferenceResponse result = apiInstance.retrieveConference(id);
             System.out.println(result);
@@ -1092,7 +1092,7 @@ public class Example {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **String**| Uniquely identifies the conference by id or name |
+ **id** | **String**| Uniquely identifies the conference by id |
 
 ### Return type
 
@@ -1112,4 +1112,3 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | Successful response with details about a conference. |  -  |
 | **404** | Conference does not exist |  -  |
-

--- a/openapi-configuration/spec3.json
+++ b/openapi-configuration/spec3.json
@@ -2206,7 +2206,7 @@
         "parameters": [
           {
             "name": "conference_id",
-            "description": "Uniquely identifies the conference by id or name",
+            "description": "Uniquely identifies the conference by id",
             "in": "path",
             "required": true,
             "schema": {
@@ -2272,7 +2272,7 @@
         "parameters": [
           {
             "name": "id",
-            "description": "Uniquely identifies the conference by id or name",
+            "description": "Uniquely identifies the conference by id",
             "in": "path",
             "required": true,
             "schema": {

--- a/src/main/java/com/telnyx/sdk/api/ConferenceCommandsApi.java
+++ b/src/main/java/com/telnyx/sdk/api/ConferenceCommandsApi.java
@@ -1088,7 +1088,7 @@ private ApiResponse<ListParticipantsResponse> listConferenceParticipantsWithHttp
   /**
    * List conference participants
    * Lists conference participants
-   * @param conferenceId Uniquely identifies the conference by id or name (required)
+   * @param conferenceId Uniquely identifies the conference by id (required)
    * @return listConferenceParticipantsRequest
    * @throws ApiException if fails to make API call
    
@@ -1224,7 +1224,7 @@ private ApiResponse<ListConferencesResponse> listConferencesWithHttpInfo(String 
   /**
    * Retrieve a conference
    * Retrieve an existing conference
-   * @param id Uniquely identifies the conference by id or name (required)
+   * @param id Uniquely identifies the conference by id (required)
    * @return ConferenceResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -1241,7 +1241,7 @@ private ApiResponse<ListConferencesResponse> listConferencesWithHttpInfo(String 
   /**
    * Retrieve a conference
    * Retrieve an existing conference
-   * @param id Uniquely identifies the conference by id or name (required)
+   * @param id Uniquely identifies the conference by id (required)
    * @return ApiResponse&lt;ConferenceResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details


### PR DESCRIPTION
[TELAPPS-2740](https://telnyx.atlassian.net/browse/TELAPPS-2740)

If it needs work with name it will return many conferences with the same name since it does not require to be active.