### PR TITLE
fix: merge next into release PR to carry code changes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,9 +11,10 @@ name: Release Please
 # `next` receives new commits, which:
 #   1. Reads the Release-As version from the commit footer
 #   2. Opens a release PR targeting `master` with --release-as
-#   3. On merge, push to `master` triggers this workflow again
-#   4. github-release creates vX.Y.Z tag and GitHub Release
-#   5. publish-sonatype.yml picks up the release event and publishes to Maven Central
+#   3. Merges `next` into the release PR branch so code changes are included
+#   4. On merge, push to `master` triggers this workflow again
+#   5. github-release creates vX.Y.Z tag and GitHub Release
+#   6. publish-sonatype.yml picks up the release event and publishes to Maven Central
 #
 # Uses the official Google release-please from npm (not the Stainless fork,
 # which has broken TypeScript compilation on newer Node versions).
@@ -104,6 +105,46 @@ jobs:
             echo "prs_created=true" >> "$GITHUB_OUTPUT"
           else
             echo "prs_created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge next code into release PR
+        if: github.ref == 'refs/heads/next'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # release-please creates a PR with only version bumps (CHANGELOG,
+          # build.gradle.kts, etc). The actual SDK code changes are on `next`
+          # but NOT included in the release PR. This step merges `next` into
+          # the release PR branch so the PR carries both code and version
+          # bumps to master.
+          #
+          # Without this, master gets version bumps only — the published
+          # Maven artifact has the new version number but old code.
+
+          PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName')
+          if [ -z "$PR_BRANCH" ]; then
+            echo "No open release PR found, skipping merge"
+            exit 0
+          fi
+
+          echo "Found release PR branch: $PR_BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$PR_BRANCH" next
+          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+
+          # -X ours: on conflicts, prefer the release-please branch's version
+          # bumps (canonical version + changelog). Non-conflicting code changes
+          # from next are included normally.
+          if git merge origin/next --no-edit -X ours; then
+            git push origin "$PR_BRANCH"
+            echo "Successfully merged next into release PR branch"
+          else
+            echo "::error::Failed to merge next into release PR"
+            git merge --abort
+            exit 1
           fi
 
       - name: Run release-please (github-release)


### PR DESCRIPTION
## Problem

`release-please` creates release PRs that contain **only** version bumps (`CHANGELOG.md`, `build.gradle.kts`, `.release-please-manifest.json`). The actual SDK code changes — the ~300 generated source files pushed to `next` by `promote`/`stlc-generate` — are **not** included in the release PR.

As a result, merging the release PR into `master` ships a new version number with the **old** code. The published Maven artifact carries the new version but none of the SDK changes that motivated the release.

This is the root cause of the current broken state where `next` has 6.75.0 with all SDK code, but `master` is stuck at 6.74.0 with only version-bump commits — the code never made it across.

## Fix

Adds a new workflow step, **"Merge next code into release PR"**, that runs after `release-please` creates the release PR. It:

1. Finds the open release PR branch (label: `autorelease: pending`)
2. Checks it out
3. Merges `origin/next` into it with `-X ours`
   - `-X ours` prefers the release-please version bumps on conflict (canonical version + changelog); non-conflicting code changes from `next` are included normally
4. Pushes the updated release PR branch

With this, the release PR carries **both** the version bumps AND the SDK code changes, so `master` receives the full release on merge.

## Why `-X ours`?

release-please owns the canonical version files (`CHANGELOG.md`, `.release-please-manifest.json`, version in `build.gradle.kts`). On conflict we keep those, and let all the non-overlapping SDK code from `next` flow through unmodified.

## Related

- Follow-up sync PR (next → master) fixes the **already-broken** state: #<sync-pr-number>