### PR TITLE
fix: add code-carry merge step to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,9 +11,10 @@ name: Release Please
 # `next` receives new commits, which:
 #   1. Reads the Release-As version from the commit footer
 #   2. Opens a release PR targeting `master` with --release-as
-#   3. On merge, push to `master` triggers this workflow again
-#   4. github-release creates vX.Y.Z tag and GitHub Release
-#   5. publish-sonatype.yml picks up the release event and publishes to Maven Central
+#   3. Merges `next` into the release PR branch so code changes are included
+#   4. On merge, push to `master` triggers this workflow again
+#   5. github-release creates vX.Y.Z tag and GitHub Release
+#   6. publish-sonatype.yml picks up the release event and publishes to Maven Central
 #
 # Uses the official Google release-please from npm (not the Stainless fork,
 # which has broken TypeScript compilation on newer Node versions).
@@ -104,6 +105,65 @@ jobs:
             echo "prs_created=true" >> "$GITHUB_OUTPUT"
           else
             echo "prs_created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Merge next code into release PR
+        if: github.ref == 'refs/heads/next'
+        env:
+          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
+        run: |
+          # release-please creates a PR with only version bumps (CHANGELOG,
+          # build.gradle.kts, README, etc). The actual SDK code changes are
+          # on `next` but NOT included in the release PR. This step merges
+          # `next` into the release PR branch so the PR carries both code
+          # and version bumps to master.
+          #
+          # Without this, master gets version bumps only — the published
+          # Maven artifact has the new version number but old code.
+
+          # Use the PR number from the release-please step directly (avoids
+          # GitHub API eventual-consistency race where gh pr list doesn't see
+          # a PR that was created milliseconds ago).
+          PR_BRANCH=""
+          if [ -n "$PR_NUM" ]; then
+            sleep 3  # brief propagation delay
+            PR_BRANCH=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+          fi
+
+          # Fallback: query by label with retry
+          if [ -z "$PR_BRANCH" ]; then
+            for i in 1 2 3; do
+              PR_BRANCH=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json headRefName --jq '.[0].headRefName' 2>/dev/null || true)
+              if [ -n "$PR_BRANCH" ]; then break; fi
+              echo "PR not found yet, retrying in 5s (attempt $i)..."
+              sleep 5
+            done
+          fi
+
+          if [ -z "$PR_BRANCH" ]; then
+            echo "::warning::No open release PR found after retries, skipping merge"
+            exit 0
+          fi
+
+          echo "Found release PR branch: $PR_BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$PR_BRANCH" next
+          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+
+          # -X ours: on conflicts, prefer the release-please branch's version
+          # bumps (canonical version + changelog). Non-conflicting code changes
+          # from next are included normally.
+          if git merge origin/next --no-edit -X ours; then
+            git push origin "$PR_BRANCH"
+            echo "Successfully merged next into release PR branch"
+          else
+            echo "::error::Failed to merge next into release PR"
+            git merge --abort
+            exit 1
           fi
 
       - name: Run release-please (github-release)


### PR DESCRIPTION
## Problem

release-please creates PRs with only version bumps (CHANGELOG, build.gradle.kts, README). The actual SDK code changes on `next` were never included in the release PR.

Result: PR #174 has only 4 files — no SDK code. Merging it would publish a Maven artifact with the new version number but old code.

## Fix

Adds a **"Merge next code into release PR"** step (same as PR #440 on `telnyx-node`):

1. After release-please creates the PR, this step merges `next` into the release PR branch
2. Uses `pr_number` output directly from release-please (avoids GitHub API race condition)
3. Falls back to `gh pr list` with 3 retries (5s interval)
4. `-X ours` on conflicts prefers release-please's version bumps

## Evidence

- PR #174 before fix: 4 files (version bumps only)
- PR #174 after manual merge: 1469 files (full SDK code)

## Parity

Same pattern as TypeScript SDK (telnyx-node PR #437 + #440).