### PR TITLE
fix: check SDK_WRITE_TOKEN instead of RELEASE_PLEASE_TOKEN in release doctor

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. Add it as a repository secret.")
 fi
 
 if [ -z "${SONATYPE_USERNAME}" ]; then


### PR DESCRIPTION
## Problem

`bin/check-release-environment` checks `RELEASE_PLEASE_TOKEN`, but:
1. That secret was **never set** on this repo
2. The actual `release-please.yml` workflow uses `SDK_WRITE_TOKEN` for everything (checkout, release-pr, github-release, auto-merge)
3. `RELEASE_PLEASE_TOKEN` is a leftover from the old Stainless template

This causes the **release-doctor** CI check to always fail on PRs.

## Fix

Replace `RELEASE_PLEASE_TOKEN` check with `SDK_WRITE_TOKEN` — matching:
- What `release-please.yml` actually uses
- How the Python SDK already works (`team-telnyx/telnyx-python` checks `SDK_WRITE_TOKEN` only)