### PR TITLE
fix: suppress ByteBuddy agent warnings flaking LoggingHttpClientTest

### DIFF
--- a/telnyx-core/build.gradle.kts
+++ b/telnyx-core/build.gradle.kts
@@ -41,3 +41,10 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:5.14.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
 }
+
+// Suppress ByteBuddy dynamic agent loading warnings that pollute stderr
+// (Mockito loads byte-buddy-agent dynamically, which causes JVM warnings
+// that break LoggingHttpClientTest which captures stderr for assertions)
+tasks.withType<Test> {
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+}


### PR DESCRIPTION
## Problem

`LoggingHttpClientTest.debugLevel_logsMultilineResponseBody` is flaky — it fails intermittently because Mockito's ByteBuddy agent dynamically loads a Java agent, causing JVM warnings on stderr:

```
WARNING: A Java agent has been loaded dynamically (byte-buddy-agent)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

The test captures `System.err` and asserts exact output match. The injected warnings pollute the stream and break the assertion. This caused PR #178 (release-please) to fail CI.

## Fix

Add `-XX:+EnableDynamicAgentLoading` to test JVM args in `telnyx-core/build.gradle.kts`. This suppresses the ByteBuddy warning by telling the JVM we explicitly allow dynamic agent loading.

`telnyx-core/build.gradle.kts` is in STLC `PRESERVE_PATHS`, so this won't be overwritten by SDK generation.