### PR TITLE
fix: add --local flag so release-please scans next branch for commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,15 @@ name: Release Please
 #
 # Uses the official Google release-please from npm (not the Stainless fork,
 # which has broken TypeScript compilation on newer Node versions).
-# The --release-as flag replaces the need for the Stainless-only --changes-branch.
+#
+# release-please v17 does not have --changes-branch (a Stainless-only flag).
+# Instead, we use --local so release-please scans the local checkout (which is
+# `next`, the branch that triggered this workflow) for commits since the last
+# release, rather than making API calls to scan `master` (where there are 0
+# new commits — the code changes are on `next`).
+#
+# The --release-as flag sets the version number; --local makes release-please
+# find the actual commits to include in the release PR.
 
 on:
   push:
@@ -88,6 +96,7 @@ jobs:
             --target-branch master
             --config-file release-please-config.json
             --manifest-file .release-please-manifest.json
+            --local
           )
 
           if [ "${{ steps.version.outputs.has_version }}" = "true" ]; then


### PR DESCRIPTION
## Problem

Release-please runs on push to `next` but finds 0 commits and skips:
```
✔ No commits for path: ., skipping
```

This is why v6.78.0 never got a release PR — staging was promoted to `next` with `Release-As: 6.78.0`, release-please ran, but found nothing to include.

## Root Cause

release-please v17 (Google's official npm package) does **not** have `--changes-branch` (a Stainless-only flag). Without it, release-please makes API calls to scan `master` for commits since the last release. But the code changes are on `next`, not `master`.

The workflow comment claimed `--release-as replaces --changes-branch` — this is **wrong**. `--release-as` only sets the version number. It doesn't tell release-please where to find commits.

Ruby's release-please only worked by accident — manual fix PRs (#283, #284, #286) were merged directly to master, giving release-please commits to find. Java has no such manual fixes, so it finds 0 and skips.

## Fix

Add `--local` flag to the `release-pr` command. This makes release-please use the local checkout (which is `next` — the branch that triggered the workflow) instead of making API calls to scan `master`. Release-please then finds the promote commits on `next` and includes them in the release PR.

## Verification

Before: `Splitting 0 commits by path` → `commits: 0` → `No commits for path: ., skipping`

After (expected): release-please scans local `next` checkout → finds promote commit → creates release PR targeting `master`