### PR TITLE
fix: use git reset --hard for tree replacement, force-push, and fix PR URL regex in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,7 +107,7 @@ jobs:
           echo "$OUTPUT"
 
           # Parse PR number from output if a PR was created
-          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' | head -1)
+          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://(?:api\.)?github\.com/(?:repos/[^/]+/[^/]+/)?pulls?/\d+' | head -1)
           if [ -n "$PR_URL" ]; then
             PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
             echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
@@ -176,10 +176,8 @@ jobs:
           # Replace entire working tree from next (exact tree, no merge)
           # git rm handles deletions (files removed in next but still in this branch)
           # git clean removes untracked files (node_modules created by npx release-please)
-          git rm -rf . 2>/dev/null || true
-          git checkout origin/next -- .
+          git reset --hard origin/next
           git clean -fdx
-          git add -A
 
           # Restore version-bump files from the release PR branch
           for f in CHANGELOG.md build.gradle.kts README.md .release-please-manifest.json; do
@@ -196,7 +194,7 @@ jobs:
             echo "No changes after syncing next code"
           else
             git commit -m "chore: sync code from next into release PR"
-            git push origin "$PR_BRANCH"
+            git push --force origin "$PR_BRANCH"
             echo "Successfully synced next code into release PR branch (tree replacement)"
           fi
       - name: Run release-please (github-release)


### PR DESCRIPTION
## What

Three fixes for the tree replacement sync step in `release-please.yml`, backported from the Python SDK (PRs #375 and #380).

### Fix 1: `git reset --hard` instead of `git rm` + `git checkout`

The sequence `git rm -rf .` + `git checkout origin/next -- .` is a **no-op**. After `git rm -rf .` empties the index, `git checkout origin/next -- .` resolves pathspec `.` against the empty index and matches zero paths. The release PR never gets the actual SDK code from `next` — only version-bump files ship.

**Fix:** Replace with `git reset --hard origin/next` which atomically replaces both index and working tree.

### Fix 2: PR URL regex doesn't match release-please v17 output

The grep only matched `https://github.com/owner/repo/pull/123` but release-please v17 outputs `https://api.github.com/repos/owner/repo/pulls/123` (api subdomain, `pulls` plural, `/repos/` path). `PR_NUM` was always empty, causing the sync step to fall back to a label-based search that found stale branches.

**Fix:** Updated regex to match both URL formats.

### Fix 3: `git push --force` for non-fast-forward commits

`git reset --hard` rewrites branch history (tree replacement), so `git push` is rejected as non-fast-forward. The old buggy no-op never produced a commit to push, hiding this.

**Fix:** Changed `git push` to `git push --force`.

## Evidence

See team-telnyx/telnyx-python PRs #375 and #380 for the full root-cause analysis and verification.