### PR TITLE
fix(release): document master-branch commit-scan requirement for release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,6 +85,12 @@ jobs:
             echo "Release-As version: $VERSION"
           fi
 
+      # NOTE: release-pr collects commits since the last release on the TARGET
+      # branch (master) — commits on `next` (chore promotes + Release-As
+      # footers) are invisible to this scan. The scan needs >=1 non-hidden
+      # (user-facing) commit ON MASTER to build the PR; the promoted SDK
+      # content then enters the PR via the tree-replacement sync step below,
+      # and the version comes from --release-as (read off next above).
       - name: Run release-please (release-pr)
         if: github.ref == 'refs/heads/next'
         id: release-pr


### PR DESCRIPTION
release-pr scans commits since the last release on the TARGET branch (master); `next`-side promotes and their Release-As footers are invisible to it. Releases 6.78/6.79 only built because coincidental fix-typed hotfixes existed on master; with only hidden `ci:` commits since v6.79.0, the pending 6.80.0 (Storage KV spec) release PR was silently skipped ('No user facing commits found'). This fix-typed commit both documents the trap in the workflow and provides the user-facing commit the scan requires, unblocking 6.80.0.