### PR TITLE
fix(release): take first Release-As match (multiline output broke GITHUB_OUTPUT)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,7 @@ jobs:
           # into the generate commit. Find the latest one in main history.
           for commit in $(git rev-list HEAD --max-count=50); do
             BODY=$(git log -1 --format=%b "$commit")
-            RA=$(echo "$BODY" | grep -oP 'Release-As:\s*\K[\d.]+' || true)
+            RA=$(echo "$BODY" | grep -oP 'Release-As:\s*\K[\d.]+' | head -1 || true)
             if [ -n "$RA" ]; then
               VERSION="$RA"
               break


### PR DESCRIPTION
The Read-Release-As step's `grep -oP` returns every match; a squash/back-merge commit whose body aggregates multiple promote messages (squash_merge_commit_message=COMMIT_MESSAGES) yields a multiline VERSION, and writing it to $GITHUB_OUTPUT fails the run before release-pr executes ('Unable to process file command output / Invalid format'). Seen live on telnyx-ruby run 28665702728. Take the first (newest, since the loop walks newest-first) match: `| head -1`.