### PR TITLE
fix(release): ghost guard also verifies the GitHub Release exists

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -247,6 +247,8 @@ jobs:
 
       - name: Verify release commit produced a tag (ghost-release guard)
         if: github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # `github-release` exits 0 even when it finds nothing to release ([]).
           # If the commit that triggered this run is a merged `release: X.Y.Z`
@@ -260,7 +262,11 @@ jobs:
             exit 0
           fi
           if git ls-remote --exit-code --tags origin "v$VER" >/dev/null 2>&1; then
-            echo "Tag v$VER exists - release verified"
+            if ! gh api "repos/${{ github.repository }}/releases/tags/v$VER" >/dev/null 2>&1; then
+              echo "::error::Tag v$VER exists but there is no GitHub Release for it - the publish workflow (release: published) will never fire. Create it: gh release create v$VER --generate-notes"
+              exit 1
+            fi
+            echo "Tag v$VER and its GitHub Release exist - release verified"
           else
             echo "::error::Merged release commit for $VER but no v$VER tag exists. github-release silently no-opped (merged release PR likely missing the autorelease pending label). Add the label to the merged PR and re-run this workflow."
             exit 1


### PR DESCRIPTION
If github-release creates the tag but fails creating the Release object, publish workflows (release: published trigger) never fire — package silently never ships. Extend the ghost-release guard to also assert the GitHub Release exists for the tag.