### PR TITLE
fix(release): configure identity before synthetic commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -117,6 +117,11 @@ jobs:
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BASE_BRANCH:refs/remotes/origin/release-base" next
           RELEASE_BASE=$(git rev-parse refs/remotes/origin/release-base)
+
+          # git commit-tree needs an explicit identity on fresh Actions runners.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           RELEASE_FILES=("CHANGELOG.md" "build.gradle.kts" "README.md" ".release-please-manifest.json")
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
           SCAN_TREE=$(git write-tree)
@@ -218,8 +223,6 @@ jobs:
           fi
 
           echo "Found release PR branch: $PR_BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"


### PR DESCRIPTION
## Summary
- configure the canonical `github-actions[bot]` Git identity before `git commit-tree`
- keep that repository-local identity available for the later release-branch sync commit
- remove the duplicate identity setup that previously ran only after synthetic commit creation

## Root cause
The first clean-history production run failed before release-please with `Author identity unknown` because fresh Actions runners have no Git author/committer identity. The existing setup happened later in the job.

Failed proof run: https://github.com/team-telnyx/telnyx-java/actions/runs/29818813102

## Validation
- `git diff --check`
- `actionlint -ignore SC2034 .github/workflows/release-please.yml`
- isolated regression proof: `git commit-tree` fails without identity and succeeds after the exact bot identity configuration
