### PR TITLE
chore: add repository code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all repository changes
+* @ankitTelnyx


### PR DESCRIPTION
## Summary
- add `.github/CODEOWNERS` with `@ankitTelnyx` as the default owner for all repository changes
- keep existing branch protection and ruleset behavior unchanged; code-owner approval is **not** made mandatory
- Companion staging workflow change: `team-telnyx/telnyx-java-staging` will restore this file during promotion.

## Verification
- verified `@ankitTelnyx` resolves to an active GitHub user with repository access
- `git diff --check`
- confirmed the PR contains only `.github/CODEOWNERS`

## Companion staging PR
- https://github.com/team-telnyx/telnyx-java-staging/pull/195
