### PR TITLE
ci: run Java build and tests on larger runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ${{ github.repository == 'stainless-sdks/telnyx-java' && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest-16-cores
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   test:
     timeout-minutes: 30
     name: test
-    runs-on: ${{ github.repository == 'stainless-sdks/telnyx-java' && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest-16-cores
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- run the production Java SDK build and test jobs on GitHub's 16-core hosted runners
- preserve the existing 30-minute job timeout and required check names
- prevent standard `ubuntu-latest` runners from shutting down before the generated SDK test suite completes

## Evidence
- release PR #216 test run `31797977144` was cancelled twice during `:telnyx-proguard-test:proguardJar` after the runner received a shutdown signal
- the generated tree itself already passed staging CI on a larger runner
- the production repo has no access to the staging repository's `telnyx-4xlarge` runner group, so this uses the available GitHub-hosted large-runner label
- `actionlint` and `git diff --check` pass

## Follow-up
After this PR merges, rerun staging promotion so `next` and release PR #216 receive the production-owned CI workflow, then validate the release end-to-end.
