### PR TITLE
ci: shard Java compatibility tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,21 @@ jobs:
           SHA: ${{ github.sha }}
           PROJECT: telnyx-java
         run: ./scripts/upload-artifacts
-  test:
+  test-shard:
     timeout-minutes: 30
-    name: test
+    name: test-shard (${{ matrix.name }})
     runs-on: ${{ github.repository == 'stainless-sdks/telnyx-java' && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: sdk
+            tasks: test -x :telnyx-proguard-test:test
+          - name: proguard
+            tasks: :telnyx-proguard-test:testProGuard
+          - name: r8
+            tasks: :telnyx-proguard-test:testR8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -105,5 +115,21 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
 
-      - name: Run tests
-        run: ./scripts/test
+      - name: Run ${{ matrix.name }} tests
+        run: ./gradlew ${{ matrix.tasks }}
+
+  test:
+    timeout-minutes: 5
+    name: test
+    runs-on: ubuntu-latest
+    needs: test-shard
+    if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
+    steps:
+      - name: Verify all test shards passed
+        env:
+          SHARD_RESULT: ${{ needs.test-shard.result }}
+        run: |
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "One or more Java test shards failed: $SHARD_RESULT"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- run ordinary SDK tests independently from ProGuard and R8 compatibility checks
- keep all three test paths on runners available to this repository
- preserve the required aggregate `test` status context

## Root cause
The monolithic `./gradlew test` job was repeatedly terminated while executing the ProGuard compatibility graph on `ubuntu-latest`. Larger-runner labels tested for this repository remained unscheduled, so the durable fallback is to parallelize the independent task graphs.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `./gradlew test -x :telnyx-proguard-test:test --dry-run`
- `./gradlew :telnyx-proguard-test:testProGuard --dry-run`
- `./gradlew :telnyx-proguard-test:testR8 --dry-run`

The SDK dry-run excludes both compatibility paths; the ProGuard and R8 dry-runs resolve their respective tasks.