### PR TITLE
ci: extend Java compatibility shard timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           PROJECT: telnyx-java
         run: ./scripts/upload-artifacts
   test-shard:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: test-shard (${{ matrix.name }})
     runs-on: ${{ github.repository == 'stainless-sdks/telnyx-java' && 'depot-ubuntu-24.04-4' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork


### PR DESCRIPTION
## Summary
- increase the Java compatibility shard timeout from 30 to 60 minutes
- retain separate SDK, ProGuard, and R8 shards and the required aggregate `test` context

## Evidence
PR #216 fresh CI on the sharded workflow showed:
- SDK shard passed in 15m30s
- ProGuard runner received a shutdown signal after 12m23s
- R8 was still executing when the explicit 30-minute timeout cancelled it

The 60-minute ceiling removes the deterministic R8 timeout while preserving full coverage.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `./gradlew test -x :telnyx-proguard-test:test --dry-run`
- `./gradlew :telnyx-proguard-test:testProGuard --dry-run`
- `./gradlew :telnyx-proguard-test:testR8 --dry-run`