### PR TITLE
ci: cap Java test shard heap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,9 @@ jobs:
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
 
       - name: Run ${{ matrix.name }} tests
-        run: ./gradlew ${{ matrix.tasks }}
+        run: |
+          ./gradlew ${{ matrix.tasks }} \
+            -Dorg.gradle.jvmargs="-Xms2g -Xmx8g -XX:+UseParallelGC -XX:InitialCodeCacheSize=256m -XX:ReservedCodeCacheSize=1G -XX:MetaspaceSize=512m -XX:MaxMetaspaceSize=2G -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=4 -XX:CICompilerCount=4 -XX:+OptimizeStringConcat -XX:+UseStringDeduplication"
 
   test:
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- cap the production CI test-shard Gradle daemon at the previously working 2–8 GiB range
- keep the generated release configuration at 12 GiB for larger staging runners
- preserve all SDK, ProGuard, R8, and aggregate `test` coverage

## Root cause evidence
After #219 removed the deterministic 30-minute timeout, release PR #216 still lost separate `ubuntu-latest` runners while using its newly generated `-Xms12g -Xmx12g` configuration:
- SDK shard: cancelled after 16m22s
- R8 shard: cancelled after 15m14s
- both steps ended with `The operation was canceled`, not test assertions

Current `master` uses `-Xms2g -Xmx8g`, and all three shards passed there. The release PR changes that file to 12/12 GiB, leaving too little host headroom on standard production runners.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- all three shard task dry-runs passed with the command-line override
- exact release head `9a5b8fa8328df79a22ef442d4e2c401c909df690` precedence probe showed the daemon starting with `-Xms2g -Xmx8g`, overriding its generated 12/12 GiB properties