### PR TITLE
ci: compile Kotlin in process for test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,11 @@ jobs:
 
       - name: Run ${{ matrix.name }} tests
         run: |
-          ./gradlew ${{ matrix.tasks }} \
-            -Dorg.gradle.jvmargs="-Xms2g -Xmx8g -XX:+UseParallelGC -XX:InitialCodeCacheSize=256m -XX:ReservedCodeCacheSize=1G -XX:MetaspaceSize=512m -XX:MaxMetaspaceSize=2G -XX:TieredStopAtLevel=1 -XX:GCTimeRatio=4 -XX:CICompilerCount=4 -XX:+OptimizeStringConcat -XX:+UseStringDeduplication"
+          kotlin_args=()
+          if ! grep -q -- '-Xmx8g' gradle.properties; then
+            kotlin_args+=("-Pkotlin.compiler.execution.strategy=in-process")
+          fi
+          ./gradlew ${{ matrix.tasks }} "${kotlin_args[@]}"
 
   test:
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- keep the established Kotlin daemon path for the normal 8 GiB repository configuration
- switch test shards to in-process Kotlin compilation when generated configuration no longer matches the known 8 GiB baseline
- avoid allocating a second JVM with the same large generated heap

## Root cause
PR #216 contains a generated 12 GiB Gradle heap because its larger source tree needs more than 8 GiB to compile. With the default Kotlin daemon strategy, that heap is inherited by a second JVM. This explains the earlier runner shutdowns at 12 GiB and, after #220 capped both JVMs at 8 GiB, the explicit Kotlin `java.lang.OutOfMemoryError` failures in all three shards.

The conditional keeps current `master` on its already-proven 8 GiB daemon path. Any non-baseline generated heap fails over to one in-process compiler JVM instead of two competing large JVMs. It does not modify generated SDK source or generated `gradle.properties`.

## Validation
- exact PR #216 head `e159f3b77a5f1c6e09ebee4e3164f174bad3a945`: clean `:telnyx-core:compileKotlin` with in-process compilation passed in 9m20s using the branch's 12 GiB setting
- branch-selection probe: `master` selected normal daemon args; PR #216 selected in-process args
- SDK, ProGuard, and R8 task graph dry-runs passed
- `actionlint .github/workflows/ci.yml`
- `git diff --check`