### PR TITLE
test: make Maven publication guards checkout-independent

### DIFF
--- a/.github/scripts/test_maven_publication_guard.py
+++ b/.github/scripts/test_maven_publication_guard.py
@@ -3,6 +3,8 @@ import unittest
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIR.parents[1]
+PUBLISH_WORKFLOW = REPOSITORY_ROOT / ".github/workflows/publish-sonatype.yml"
 sys.path.insert(0, str(SCRIPT_DIR))
 
 import maven_publication_guard as guard
@@ -100,7 +102,7 @@ class MavenPublicationGuardTest(unittest.TestCase):
                     self.assertIn(prefix + suffix + ".sigstore.json", self.urls)
 
     def test_publish_workflow_bounds_memory_and_runtime(self):
-        workflow = Path(".github/workflows/publish-sonatype.yml").read_text(encoding="utf-8")
+        workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("runs-on: ubuntu-latest", workflow)
         self.assertIn("timeout-minutes: 60", workflow)
         self.assertIn("-Xmx8g", workflow)
@@ -108,7 +110,7 @@ class MavenPublicationGuardTest(unittest.TestCase):
         self.assertIn("--no-daemon", workflow)
 
     def test_manual_recovery_uses_trusted_policy_and_attested_tag_source(self):
-        workflow = Path(".github/workflows/publish-sonatype.yml").read_text(encoding="utf-8")
+        workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('ref: master', workflow)
         self.assertIn('path: trusted-policy', workflow)
         self.assertIn('git merge-base --is-ancestor "${TAG_SHA}" origin/master', workflow)
@@ -118,7 +120,7 @@ class MavenPublicationGuardTest(unittest.TestCase):
         self.assertIn('refs/heads/master', workflow)
 
     def test_publish_workflow_preflights_and_postflights_immutable_coordinates(self):
-        workflow = Path(".github/workflows/publish-sonatype.yml").read_text(encoding="utf-8")
+        workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("maven_publication_guard.py preflight", workflow)
         self.assertIn("maven_publication_guard.py postflight", workflow)
         self.assertIn("needs_publish == 'true'", workflow)


### PR DESCRIPTION
## Summary
- resolve publication workflow assertions relative to the trusted policy script checkout
- make guard tests independent of the GitHub Actions workspace current directory
- unblock immutable-tag publication without weakening preflight or postflight checks

## Root cause
The production publication workflow invokes the trusted test script by absolute checkout path while the process current directory remains the workspace root. Three workflow-policy tests incorrectly resolved `.github/workflows/publish-sonatype.yml` from that current directory instead of the trusted policy checkout.

## Validation
- reproduced the hosted failure by invoking the script from `/tmp`
- 12/12 Maven publication guard tests pass from `/tmp`
- 24/24 exact-head gate tests pass
- Python compilation passes
- `actionlint .github/workflows/publish-sonatype.yml` passes
- `git diff --check` passes

Follow-up for DOT-2059 and failed publication run `31970069655`.
