### PR TITLE
fix: attest all published Java modules

### DIFF
--- a/.github/scripts/maven_publication_guard.py
+++ b/.github/scripts/maven_publication_guard.py
@@ -19,6 +19,7 @@ MODULES = (
     "telnyx-client-okhttp",
     "telnyx-core",
     "telnyx-lib",
+    "telnyx-websocket",
 )
 PRIMARY_SUFFIXES = (
     ".jar",

--- a/.github/scripts/test_maven_publication_guard.py
+++ b/.github/scripts/test_maven_publication_guard.py
@@ -81,13 +81,14 @@ class MavenPublicationGuardTest(unittest.TestCase):
                 with self.assertRaisesRegex(guard.GuardError, "invalid release version"):
                     guard.expected_urls(invalid)
 
-    def test_inventory_has_four_published_java_modules(self):
+    def test_inventory_has_all_published_java_modules(self):
         self.assertEqual(
             (
                 "telnyx",
                 "telnyx-client-okhttp",
                 "telnyx-core",
                 "telnyx-lib",
+                "telnyx-websocket",
             ),
             guard.MODULES,
         )


### PR DESCRIPTION
## Summary
- include the published `telnyx-websocket` module in Maven Central preflight/postflight attestation
- require its primary artifacts, signatures, and Sigstore bundles alongside the other four modules
- update the regression inventory to cover all five production publications

## Root cause
The first successful `v6.87.0` publication run proved that Gradle publishes five production modules. The guard attested only four, so it could report completion without checking `com.telnyx.sdk:telnyx-websocket`.

## Validation
- added the missing module to the expected inventory first and observed the regression test fail
- 12/12 Maven publication guard tests pass
- 24/24 exact-head release-gate tests pass
- Python compilation passes
- Maven Central `6.87.0` is complete across all 75 required artifact URLs (five modules × five primary artifacts × artifact/signature/Sigstore bundle)
- `actionlint .github/workflows/publish-sonatype.yml` passes
- `git diff --check` passes

Follow-up for DOT-2059. The existing staging promotion policy already preserves both modified production-owned script paths.
