### PR TITLE
fix: wait past skipped duplicate checks

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -430,8 +430,12 @@ class ReleasePRAutoMergeGate:
             ]
             if successes:
                 continue
-            if any(check.get("status") != "completed" for check in candidates) or not candidates:
-                raise ChecksPending("required exact-head check pending or missing: %s" % name)
+            if (
+                any(check.get("status") != "completed" for check in candidates)
+                or not candidates
+                or all(check.get("conclusion") == "skipped" for check in candidates)
+            ):
+                raise ChecksPending("required exact-head check pending, skipped, or missing: %s" % name)
             raise GateError("required exact-head check failed: %s" % name)
 
     @staticmethod

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -311,6 +311,25 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         client.snapshot["required_contexts"].append("new-policy")
         self.assert_blocked(client, "timed out")
 
+    def test_skipped_duplicate_can_become_successful_before_timeout(self):
+        skipped = FixtureClient.good_snapshot()
+        next(c for c in skipped["checks"] if c["name"] == "test").update(
+            status="completed", conclusion="skipped"
+        )
+        ready = FixtureClient.good_snapshot()
+        client = SequenceClient([skipped, ready, ready])
+        sleeps = []
+        result = self.gate(client, attempts=2, sleeps=sleeps).run(415, HEAD, True)
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(sleeps, [0])
+
+    def test_skipped_only_required_check_times_out_fail_closed(self):
+        client = FixtureClient()
+        next(c for c in client.snapshot["checks"] if c["name"] == "test").update(
+            status="completed", conclusion="skipped"
+        )
+        self.assert_blocked(client, "timed out")
+
     def test_pending_check_can_become_successful_before_timeout(self):
         pending = FixtureClient.good_snapshot()
         next(c for c in pending["checks"] if c["name"] == "build").update(


### PR DESCRIPTION
## Summary
- treat a required context represented only by skipped duplicate/path-filtered runs as retryable while the trusted gate is polling
- continue to fail closed if no authoritative success appears before the bounded timeout
- preserve immediate failure for genuine terminal failure/cancellation results

## Root cause
The real Java Release Please event started the trusted gate before the main CI aggregate `test` context existed. A separate path-filtered CI invocation had already emitted a skipped `test` context on the same exact head. The gate treated that non-authoritative skipped duplicate as a terminal failure instead of continuing its bounded poll, so automatic event processing stopped even though all authoritative checks later passed.

## TDD
- added a regression where skipped `test` is replaced by an authoritative exact-head success during polling; it failed before implementation
- added a skipped-only timeout regression proving the policy still fails closed

## Validation
- 26/26 exact-head gate tests pass
- 12/12 Maven publication guard tests pass
- Python compilation passes
- targeted `actionlint` passes
- `git diff --check` passes

Follow-up for the real DOT-2059 hosted lifecycle. This does not accept skipped checks: it only waits for an authoritative success and still rejects skipped-only state at timeout.
