### PR TITLE
ci: sync Java release readiness policy to next

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -409,6 +409,9 @@ class ReleasePRAutoMergeGate:
         expected: Dict[str, str] = dict(self.config.expected_checks)
         for context in live:
             self._require(isinstance(context, str) and context, "invalid live required context")
+            # This gate publishes release-provenance; do not wait on itself.
+            if context == "release-provenance":
+                continue
             expected.setdefault(context, "github-actions")
 
         checks = snapshot.get("checks")

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -159,6 +159,12 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertEqual(result, {"status": "ready", "head_sha": HEAD, "dry_run": True})
         self.assertEqual(client.merge_calls, [])
 
+    def test_required_release_provenance_does_not_wait_on_its_own_status(self):
+        client = FixtureClient()
+        client.snapshot["required_contexts"].append("release-provenance")
+        result = self.gate(client).run(415, HEAD, True)
+        self.assertEqual(result, {"status": "ready", "head_sha": HEAD, "dry_run": True})
+
     def test_config_inventory_contains_exactly_the_seven_authorized_sdk_repositories(self):
         expected = {
             "team-telnyx/telnyx-python": ("master", "team-telnyx/telnyx-python-staging"),

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class JavaGateTests(unittest.TestCase):
+    def test_phase1_duplicate_full_suites_retained(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        for job in ("lint:", "build:", "test:"):
+            with self.subTest(job=job):
+                self.assertIn(job, workflow)
+        self.assertNotIn("classify production CI", workflow)
+
+    def test_readiness_is_trusted_and_dry_run(self):
+        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("github.event.repository.default_branch || 'master'", workflow)
+        self.assertIn("--dry-run", workflow)
+        self.assertNotIn("--merge", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch || 'master' }}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -1,0 +1,141 @@
+name: Exact-head release PR readiness
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Release Please PR number
+        required: true
+        type: number
+      expected_head:
+        description: Exact 40-character PR head SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: write
+  actions: read
+
+concurrency:
+  group: release-pr-readiness-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  release-provenance:
+    name: release-provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      EVENT_TITLE: ${{ github.event.pull_request.title }}
+      INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+      INPUT_EXPECTED_HEAD: ${{ inputs.expected_head }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve immutable candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            HEAD_SHA="$INPUT_EXPECTED_HEAD"
+            CANDIDATE=true
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            if [[ "$EVENT_HEAD_REF" == release-please--* ]] && \
+               [[ "$EVENT_TITLE" == release:\ * ]] && \
+               [ "$EVENT_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]; then
+              CANDIDATE=true
+            else
+              CANDIDATE=false
+            fi
+          fi
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid immutable head SHA" >&2
+            exit 1
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "head_sha=$HEAD_SHA"
+            echo "candidate=$CANDIDATE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mark non-release PR as not applicable
+        if: steps.candidate.outputs.candidate == 'false'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=success \
+            --raw-field context=release-provenance \
+            --raw-field description='Not a Release Please PR; provenance gate not applicable'
+
+      - name: Mark release provenance pending
+        if: steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=pending \
+            --raw-field context=release-provenance \
+            --raw-field description='Attesting exact release head and immutable lineage'
+
+      # pull_request_target executes trusted default-branch workflow code. Never
+      # checkout or execute the pull-request head in this privileged job.
+      - name: Check out trusted default-branch policy
+        if: steps.candidate.outputs.candidate == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch || 'master' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Attest exact release head without merging
+        id: attest
+        if: steps.candidate.outputs.candidate == 'true'
+        continue-on-error: true
+        env:
+          MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          PR_NUMBER: ${{ steps.candidate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          python3 .github/scripts/release_pr_auto_merge.py \
+            --pr-number "$PR_NUMBER" \
+            --expected-head "$HEAD_SHA" \
+            --dry-run
+
+      - name: Publish exact-head release provenance result
+        if: always() && steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+          OUTCOME: ${{ steps.attest.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" = "success" ]; then
+            STATE=success
+            DESCRIPTION='Exact release head, lineage, metadata, and checks are ready'
+          else
+            STATE=failure
+            DESCRIPTION='Exact release readiness attestation failed closed'
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state="$STATE" \
+            --raw-field context=release-provenance \
+            --raw-field description="$DESCRIPTION"
+          [ "$STATE" = success ]
+


### PR DESCRIPTION
## Summary
- synchronize the hosted-proven Java phase-1 exact-head release readiness policy from `master` to `next`
- preserve existing full CI while exercising the real Release Please lifecycle

## Validation
- 27 exact-head attestor tests passed
- 2 phase-1 gate contract tests passed
- workflow YAML parsing passed
- `git diff --check` passed

The cumulative Release Please PR remains manual.