### PR TITLE
fix(release): accept indented Gradle version marker

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -52,7 +52,7 @@ def require_version_only_change(kind: str, head_text: str, next_text: str, expec
     patterns = {
         "json-version": re.compile(r'(?m)^(?P<prefix>\s*"version"\s*:\s*")[^"]+(?P<suffix>",?\s*)$'),
         "toml-version": re.compile(r'(?m)^(?P<prefix>version\s*=\s*")[^"]+(?P<suffix>"\s*)$'),
-        "gradle-version": re.compile(r'(?m)^(?P<prefix>version\s*=\s*")[^"]+(?P<suffix>"\s*// x-release-please-version\s*)$'),
+        "gradle-version": re.compile(r'(?m)^(?P<prefix>\s*version\s*=\s*")[^"]+(?P<suffix>"\s*// x-release-please-version\s*)$'),
     }
     pattern = patterns.get(kind)
     if pattern is None:

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -16,6 +16,7 @@ from release_pr_auto_merge import (
     GateConfig,
     GitHubClient,
     ReleasePRAutoMergeGate,
+    require_version_only_change,
 )
 
 HEAD = "1" * 40
@@ -496,6 +497,14 @@ class WorkflowDependencyPolicyTests(unittest.TestCase):
                     continue
                 with self.subTest(workflow=workflow.name, line=line_number, action=action):
                     self.assertRegex(action, r"@[0-9a-f]{40}$")
+
+
+class GradleVersionContractTests(unittest.TestCase):
+    def test_accepts_indented_root_gradle_version_marker(self):
+        next_text = 'allprojects {\n    version = "6.78.0" // x-release-please-version\n}\n'
+        head_text = 'allprojects {\n    version = "6.92.0" // x-release-please-version\n}\n'
+
+        require_version_only_change("gradle-version", head_text, next_text, "6.92.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
The new fail-closed Java release provenance gate correctly rejected whole-file Gradle drift, but its version-marker regex required `version = ...` at column zero. The generated root `build.gradle.kts` indents that marker inside `allprojects`, so release PR #237 failed closed despite containing the intended version-only difference.

## Fix
Allow leading whitespace before the single marked Gradle version assignment. The gate still requires exactly one `x-release-please-version` marker and exact equality with `next` after normalizing that version.

## Validation
- RED/GREEN regression test uses the real indented root Gradle shape
- 30 release gate tests pass
- 4 release workflow hardening tests pass
- Python compilation, actionlint, and diff checks pass