### PR TITLE
fix(release): remove secrets from release doctor

### DIFF
--- a/.github/scripts/test_release_workflow_hardening.py
+++ b/.github/scripts/test_release_workflow_hardening.py
@@ -62,6 +62,19 @@ class ReleaseWorkflowHardeningTests(unittest.TestCase):
         self.assertIn("--force-with-lease", workflow)
         self.assertNotIn("git push --force origin", workflow)
 
+    def test_release_doctor_does_not_receive_publishing_secrets(self):
+        workflow = Path(".github/workflows/release-doctor.yml").read_text()
+        script = Path("bin/check-release-environment").read_text()
+        self.assertNotIn("secrets.", workflow)
+        for secret_name in (
+            "SONATYPE_USERNAME",
+            "SONATYPE_PASSWORD",
+            "GPG_SIGNING_KEY",
+            "GPG_SIGNING_PASSWORD",
+        ):
+            self.assertNotIn(secret_name, workflow)
+            self.assertNotIn(secret_name, script)
+
     def test_auto_merge_workflow_can_only_attest(self):
         workflow = Path(".github/workflows/release-pr-auto-merge.yml").read_text()
         self.assertIn("--dry-run", workflow)

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,8 +17,3 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
-        env:
-          SONATYPE_USERNAME: ${{ secrets.TELNYX_SONATYPE_USERNAME || secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.TELNYX_SONATYPE_PASSWORD || secrets.SONATYPE_PASSWORD }}
-          GPG_SIGNING_KEY: ${{ secrets.TELNYX_SONATYPE_GPG_SIGNING_KEY || secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSWORD: ${{ secrets.TELNYX_SONATYPE_GPG_SIGNING_PASSWORD || secrets.GPG_SIGNING_PASSWORD }}

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -1,33 +1,6 @@
 #!/usr/bin/env bash
 
-errors=()
-
-if [ -z "${SONATYPE_USERNAME}" ]; then
-  errors+=("The SONATYPE_USERNAME secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-if [ -z "${SONATYPE_PASSWORD}" ]; then
-  errors+=("The SONATYPE_PASSWORD secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-if [ -z "${GPG_SIGNING_KEY}" ]; then
-  errors+=("The GPG_SIGNING_KEY secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-if [ -z "${GPG_SIGNING_PASSWORD}" ]; then
-  errors+=("The GPG_SIGNING_PASSWORD secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-lenErrors=${#errors[@]}
-
-if [[ lenErrors -gt 0 ]]; then
-  echo -e "Found the following errors in the release environment:\n"
-
-  for error in "${errors[@]}"; do
-    echo -e "- $error\n"
-  done
-
-  exit 1
-fi
+# Publishing credentials are validated by the publish workflow at release time.
+# Release Doctor does not need access to their values.
 
 echo "The environment is ready to push releases!"


### PR DESCRIPTION
## Summary
- remove Sonatype and GPG secret injection from the production Java Release Doctor workflow
- make the Release Doctor script a no-secret readiness check
- add a regression test that prevents publishing credentials from returning
- retain the Sonatype publishing workflow unchanged

## Why
SEC-281 requires Release Doctor not to receive package-publishing credentials, especially the GPG private key. This production-owned workflow and script are restored from `master` during staging promotion, so the canonical `stlc-java` generator fix must be paired with this production policy change.

## Validation
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'` — 73 passed
- `bash -n bin/check-release-environment`
- `git diff --check`

## Related
- SEC-281
- Generator: team-telnyx/stlc-java#21
- Dist: team-telnyx/stlc-java#23
- Config pin: team-telnyx/telnyx-sdk-config#1037
